### PR TITLE
rize/uri-template の制約を ^0.4 許容に緩和

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ray/aop": "^2.18",
         "ray/di": "^2.18",
         "ray/media-query": "^1.0.0-rc1",
-        "rize/uri-template": "^0.3"
+        "rize/uri-template": "^0.3 || ^0.4"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8",


### PR DESCRIPTION
## 概要

`rize/uri-template` の制約を `^0.3` から `^0.3 || ^0.4` に緩和します。
これにより、すでに `rize/uri-template ^0.4` を要求しているパッケージ
（`bear/resource` 1.29+ や `ray/aura-sql-module` 1.17.x など）と
Ray.WebQuery を同時にインストールできるようになります。

現状の `^0.3`（= `>=0.3.0 <0.4.0`）では 0.4 系を許容しないため、
これらのパッケージを使うプロジェクトでは Ray.WebQuery をインストールできません。

## 補足

- Ray.WebQuery が `rize/uri-template` を使用するのは `src/WebApiQuery.php` の
  1 箇所のみで、`new UriTemplate()` と `->expand($uri, $params)` だけです。
- `Rize\UriTemplate` の公開 API（`__construct` / `expand` / `extract`）は
  0.3 と 0.4 で変わっていません。0.4 での変更は型宣言の追加
  （PHP 8.1 の constructor property promotion・戻り値型）と
  PHP 8.4/8.5 の deprecation 対応のみです。
- 0.4 における実質的な変更は PHP 要件が `>=8.1` になった点だけで、
  Ray.WebQuery はすでに `"php": "^8.1"` を要求しているため影響はありません。

したがって本 PR は制約の緩和のみで、ソースコードやテストの変更は不要です。

## お願い

問題なければ、本変更を含む rc2 または安定版をリリースしていただけると助かります。
ダウンストリームのプロジェクトがこの点でブロックされている状況です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency constraints to support compatibility with both current and upcoming versions of the uri-template library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->