### PR TITLE
Make web query tests hermetic with a fake HTTP client

### DIFF
--- a/tests/Fake/FakeWebClient.php
+++ b/tests/Fake/FakeWebClient.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Promise\FulfilledPromise;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Fake Guzzle client that serves a canned response body.
+ *
+ * Replaces live HTTP access in tests so the suite stays hermetic and does not
+ * depend on an external URL being reachable.
+ */
+final class FakeWebClient implements ClientInterface
+{
+    public function __construct(
+        private string $body,
+        private int $status = 200,
+    ) {
+    }
+
+    public function request(string $method, $uri = '', array $options = []): ResponseInterface
+    {
+        return new Response($this->status, ['Content-Type' => 'application/json'], $this->body);
+    }
+
+    public function send(RequestInterface $request, array $options = []): ResponseInterface
+    {
+        return new Response($this->status, ['Content-Type' => 'application/json'], $this->body);
+    }
+
+    public function sendAsync(RequestInterface $request, array $options = []): PromiseInterface
+    {
+        return new FulfilledPromise($this->send($request, $options));
+    }
+
+    public function requestAsync(string $method, $uri = '', array $options = []): PromiseInterface
+    {
+        return new FulfilledPromise($this->request($method, $uri, $options));
+    }
+
+    /** @return mixed */
+    public function getConfig(?string $option = null)
+    {
+        return null;
+    }
+}

--- a/tests/Fake/FakeWebClientModule.php
+++ b/tests/Fake/FakeWebClientModule.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use GuzzleHttp\ClientInterface;
+use Override;
+use Ray\Di\AbstractModule;
+
+use function dirname;
+use function file_get_contents;
+
+/**
+ * Overrides the Guzzle client binding with a {@see FakeWebClient} so the
+ * module test does not perform live HTTP access.
+ */
+final class FakeWebClientModule extends AbstractModule
+{
+    #[Override]
+    protected function configure(): void
+    {
+        $schema = (string) file_get_contents(dirname(__DIR__, 2) . '/docs/web_query.json');
+        $this->bind(ClientInterface::class)->toInstance(new FakeWebClient($schema));
+    }
+}

--- a/tests/WebQueryModuleTest.php
+++ b/tests/WebQueryModuleTest.php
@@ -25,6 +25,7 @@ class WebQueryModuleTest extends TestCase
         $webModule = new MediaQueryWebModule(new WebQueryConfig($mediaQueryJson, ['domain' => 'ray-di.github.io']));
         $baseModule = new MediaQueryBaseModule($mediaQueries);
         $baseModule->install($webModule);
+        $baseModule->override(new FakeWebClientModule());
         $this->injector = new Injector($baseModule);
         $logger = $this->injector->getInstance(MediaQueryLoggerInterface::class);
         $this->logger = $logger;

--- a/tests/WebQueryTest.php
+++ b/tests/WebQueryTest.php
@@ -8,29 +8,36 @@ use GuzzleHttp\Client;
 use PHPUnit\Framework\TestCase;
 use Ray\MediaQuery\Exception\WebApiRequestException;
 
+use function dirname;
+use function file_get_contents;
+
 class WebQueryTest extends TestCase
 {
+    private function webQuery(): WebApiQuery
+    {
+        $schema = (string) file_get_contents(dirname(__DIR__) . '/docs/web_query.json');
+
+        return new WebApiQuery(new FakeWebClient($schema), new MediaQueryLogger(), ['domain1' => 'ray-di.github.io']);
+    }
+
     public function testRequest(): void
     {
-        $webQuery = new WebApiQuery(new Client(), new MediaQueryLogger(), ['domain1' => 'ray-di.github.io']);
         $uri = 'https://{domain1}/Ray.MediaQuery/schema/{id}.json';
-        $response = $webQuery->request('GET', $uri, ['id' => 'web_query']);
+        $response = $this->webQuery()->request('GET', $uri, ['id' => 'web_query']);
         $this->assertSame('Web query schema', $response['title']);
     }
 
     public function testGetStringBody(): void
     {
-        $webQuery = new WebApiQuery(new Client(), new MediaQueryLogger(), ['domain1' => 'ray-di.github.io']);
         $uri = 'https://{domain1}/Ray.MediaQuery/schema/{id}.json';
-        $response = $webQuery->getStringBody('GET', $uri, ['id' => 'web_query']);
+        $response = $this->webQuery()->getStringBody('GET', $uri, ['id' => 'web_query']);
         $this->assertStringContainsString('"title": "Web query schema"', $response);
     }
 
     public function testGetHttpMessage(): void
     {
-        $webQuery = new WebApiQuery(new Client(), new MediaQueryLogger(), ['domain1' => 'ray-di.github.io']);
         $uri = 'https://{domain1}/Ray.MediaQuery/schema/{id}.json';
-        $response = $webQuery->getHttpMessage('GET', $uri, ['id' => 'web_query']);
+        $response = $this->webQuery()->getHttpMessage('GET', $uri, ['id' => 'web_query']);
         $this->assertStringContainsString('"title": "Web query schema"', $response->getBody()->getContents());
     }
 


### PR DESCRIPTION
## Summary

CI was failing on **every PHP version** because the test suite fetched the `web_query` JSON schema over live HTTP from `https://ray-di.github.io/Ray.MediaQuery/schema/web_query.json`, which now returns **404**. The failures are unrelated to the code under test — they are caused by an external URL no longer being reachable.

This makes the tests hermetic so they no longer depend on the network.

## Changes

- Add `tests/Fake/FakeWebClient.php` — a fake `GuzzleHttp\ClientInterface` that serves a canned response body (no mocking framework).
- Add `tests/Fake/FakeWebClientModule.php` — overrides the `ClientInterface` binding with the fake for the module test.
- `WebQueryTest`: route the success-path tests through `FakeWebClient`, serving the schema from the local `docs/web_query.json` fixture. The invalid-request tests keep the real Guzzle client since they assert on transport failure.
- `WebQueryModuleTest`: install the fake via `override()` (a plain `install()` would lose to the existing binding because Ray.Di merges with `+=`).

No `src/` changes. The fakes live under `tests/Fake/`, which is already excluded from phpcs / PHPStan / Psalm.

## Verification

- [x] phpunit: 10/10 pass
- [x] phpcs (PSR-12): no violations
- [x] PHPStan (level max): no errors
- [x] Psalm (errorLevel 1): no errors

## Note

The remaining PHPUnit deprecations come from `rize/uri-template` 0.3 on PHP 8.5 and do not fail the suite. They are resolved by allowing `^0.4` (see #2), which can be merged on top of this once CI is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a fake web client for tests, supporting both sync and async requests with canned JSON responses.
  * Updated test setup to use the fake client and avoid live HTTP calls.
  * Refined web query tests to load expected response data from a local schema file and assert response content more directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->