### PR TITLE
Require PHP 8.2 and tighten ray/media-query to ^1.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,5 +9,5 @@ jobs:
   ci:
     uses: ray-di/.github/.github/workflows/continuous-integration.yml@v1
     with:
-      old_stable: '[" 8.1.32", "8.2.28", "8.3"]'
+      old_stable: '["8.2.28", "8.3"]'
       current_stable: 8.4

--- a/README.md
+++ b/README.md
@@ -88,5 +88,5 @@ The return type of the interface method selects how the HTTP response is handled
 
 ## Requirements
 
-- PHP 8.1+
+- PHP 8.2+
 - ray/media-query ^1.0

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "guzzlehttp/guzzle": "^7.2",
         "psr/http-message": "^2.0",
         "ray/aop": "^2.18",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "psr/http-message": "^2.0",
         "ray/aop": "^2.18",
         "ray/di": "^2.18",
-        "ray/media-query": "^1.0.0-rc1",
+        "ray/media-query": "^1.0",
         "rize/uri-template": "^0.3 || ^0.4"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary

`ray/media-query` ships PHP `^8.2` in every stable release (1.0.0–1.1.0); only its pre-release line supported PHP 8.1. The package previously required `ray/media-query: ^1.0.0-rc1`, which kept PHP 8.1 working only by resolving to a **pre-release** dependency.

This aligns Ray.WebQuery with its core dependency: require stable `ray/media-query ^1.0` and raise the package's own requirement to PHP `^8.2`, dropping PHP 8.1.

## Changes

- `composer.json`: `ray/media-query` → `^1.0`, `php` → `^8.2`
- CI: drop `8.1.32` from the test matrix
- README: PHP 8.2+

## Verification

Resolved against `ray/media-query` 1.1.0 (PHP 8.2 platform):

- [x] phpunit: 10/10 pass, **0 deprecations** (`rize/uri-template` resolves to 0.4, which fixes the PHP 8.5 deprecations 0.3 emitted)
- [x] PHPStan (level max): no errors
- [x] Psalm: clean, 100% inferred

No source changes; public API and behaviour are unchanged.

## Note

Dropping PHP 8.1 reduces the supported platform set, so this is intended for a **1.1.0** release rather than a 1.0.x patch.